### PR TITLE
Updated index.html.erb to include clearfix so background fills page

### DIFF
--- a/app/views/stats/index.html.erb
+++ b/app/views/stats/index.html.erb
@@ -335,4 +335,5 @@ green_color = 	'fillColor : "rgba(92,184,92,0.5)",
 	});
 
 
-</script
+</script>
+<div class="ui-helper-clearfix"> </div>


### PR DESCRIPTION
When I installed the plugin I noticed that the background behind the content div did not fill the whole space. I added a clearfix div at the bottom to fix the problem.